### PR TITLE
add Next type and implement exact transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,11 +478,11 @@ mod example {
             &mut self,
             event: &Event,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> EventResponse<ExampleState> {
+        ) -> impl Into<EventResponse<ExampleState>> {
             match event {
                 Event::A => {
                     // Do nothing with this event and pass handling to the next highest state.
-                    EventResponse::Defer
+                    EventResponse::Next(Next::None)
                 }
                 Event::B => {
                     // Do nothing and stop event handling immediately.
@@ -490,7 +490,9 @@ mod example {
                 }
                 Event::C => {
                     // Transitition to the Foo state and stop event handling.
-                    EventResponse::Transition(ExampleState::Foo)
+                    // EventResponse implements `From` for `StateEnum`, `Option<StateEnum>`,
+                    // and `Next<StateEnum>` for convenience.
+                    ExampleState::Foo.into()
                 }
             }
         }

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -26,7 +26,7 @@ mod blinky {
     }
 
     impl TopState<BlinkyState> for Top {
-        fn init(&mut self) -> Option<BlinkyState> {
+        fn init(&mut self) -> impl Into<Next<BlinkyState>> {
             Some(BlinkyState::Enabled)
         }
     }
@@ -40,7 +40,10 @@ mod blinky {
 
     #[superstate(Top)]
     impl State<BlinkyState> for Enabled {
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BlinkyState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BlinkyState>> {
             Some(BlinkyState::LedOn)
         }
     }
@@ -51,13 +54,17 @@ mod blinky {
 
     #[superstate(Enabled)]
     impl State<BlinkyState> for LedOn {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BlinkyState> {
-            StateEntry::State(Self {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BlinkyState, Self> {
+            Self {
                 entry_time: Instant::now(),
-            })
+            }
+            .into()
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BlinkyState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BlinkyState>> {
             if self.entry_time.elapsed() >= superstates.top.blink_period {
                 Some(BlinkyState::LedOff)
             } else {
@@ -72,13 +79,17 @@ mod blinky {
 
     #[superstate(Enabled)]
     impl State<BlinkyState> for LedOff {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BlinkyState> {
-            StateEntry::State(Self {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BlinkyState, Self> {
+            Self {
                 entry_time: Instant::now(),
-            })
+            }
+            .into()
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BlinkyState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BlinkyState>> {
             if self.entry_time.elapsed() >= superstates.top.blink_period {
                 Some(BlinkyState::LedOn)
             } else {

--- a/examples/events.rs
+++ b/examples/events.rs
@@ -22,7 +22,7 @@ mod hunter {
     pub struct Top;
 
     impl TopState<HunterState, Event> for Top {
-        fn handle_event(&mut self, event: &Event) -> Option<HunterState> {
+        fn handle_event(&mut self, event: &Event) -> impl Into<Next<HunterState>> {
             match event {
                 Event::StomachGrumbled => Some(HunterState::Hunting),
                 Event::PreyCaught => Some(HunterState::Cooking),
@@ -46,13 +46,13 @@ mod hunter {
             &mut self,
             event: &Event,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> EventResponse<HunterState> {
+        ) -> impl Into<EventResponse<HunterState>> {
             match event {
-                Event::MeatCooked => EventResponse::Transition(HunterState::Top),
+                Event::MeatCooked => HunterState::Top.into(),
                 // ignore Top state's logic to start hunting when stomach grumbles
                 Event::StomachGrumbled => EventResponse::Drop,
                 // defer other events to superstates
-                _ => EventResponse::Defer,
+                _ => None.into(),
             }
         }
     }

--- a/examples/test_mock.rs
+++ b/examples/test_mock.rs
@@ -62,9 +62,9 @@ mod example {
 
     #[superstate(Top)]
     impl State<ExampleState> for Foo {
-        fn enter(superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, ExampleState> {
+        fn enter(superstates: &mut Self::Superstates<'_>) -> StateEntry<ExampleState, Self> {
             superstates.top.gpio.set_high();
-            StateEntry::State(Self)
+            Self.into()
         }
     }
 
@@ -72,9 +72,9 @@ mod example {
 
     #[superstate(Top)]
     impl State<ExampleState> for Bar {
-        fn enter(superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, ExampleState> {
+        fn enter(superstates: &mut Self::Superstates<'_>) -> StateEntry<ExampleState, Self> {
             superstates.top.gpio.set_low();
-            StateEntry::State(Self)
+            Self.into()
         }
     }
 }

--- a/moku-macros/src/metadata.rs
+++ b/moku-macros/src/metadata.rs
@@ -702,7 +702,7 @@ impl Metadata {
                                                 *self = Self::#children(node);
                                                 None
                                             }
-                                            ::moku::internal::NodeEntry::Transition(new_target) => Some(new_target),
+                                            ::moku::internal::NodeEntry::Target(new_target) => Some(new_target),
                                         }
                                     }
                                 )*

--- a/moku-macros/src/metadata.rs
+++ b/moku-macros/src/metadata.rs
@@ -475,7 +475,7 @@ impl Metadata {
 
                 if state.autogen_enter {
                     imp.items.push(parse_quote! {
-                        fn enter(_superstates: &mut Self::Superstates<'_>) -> ::moku::StateEntry<Self, #state_enum> {
+                        fn enter(_superstates: &mut Self::Superstates<'_>) -> ::moku::StateEntry<#state_enum, Self> {
                             ::moku::StateEntry::State(Self {})
                         }
                     });
@@ -602,9 +602,9 @@ impl Metadata {
                             &mut self,
                             state: &mut super::#state_ident,
                             superstates: &mut <super::#state_ident as ::moku::State<#state_enum, #event>>::Superstates<'_>,
-                        ) -> Option<#state_enum> {
+                        ) -> ::moku::Next<#state_enum> {
                             match self {
-                                Self::None => None,
+                                Self::None => ::moku::Next::None,
                                 #(Self::#children(node) => node.update(&mut #superstates::new(state, superstates)),)*
                             }
                         }
@@ -613,9 +613,9 @@ impl Metadata {
                             &mut self,
                             state: &mut super::#state_ident,
                             superstates: &mut <super::#state_ident as ::moku::State<#state_enum, #event>>::Superstates<'_>,
-                        ) -> Option<#state_enum> {
+                        ) -> ::moku::Next<#state_enum> {
                             match self {
-                                Self::None => None,
+                                Self::None => ::moku::Next::None,
                                 #(Self::#children(node) => node.update_in_need(&mut #superstates::new(state, superstates)),)*
                             }
                         }
@@ -624,9 +624,9 @@ impl Metadata {
                             &mut self,
                             state: &mut super::#state_ident,
                             superstates: &mut <super::#state_ident as ::moku::State<#state_enum, #event>>::Superstates<'_>,
-                        ) -> Option<#state_enum> {
+                        ) -> ::moku::Next<#state_enum> {
                             match self {
-                                Self::None => None,
+                                Self::None => ::moku::Next::None,
                                 #(Self::#children(node) => {
                                     node.top_down_update(&mut #superstates::new(state, superstates))
                                 })*
@@ -637,9 +637,9 @@ impl Metadata {
                             &mut self,
                             state: &mut super::#state_ident,
                             superstates: &mut <super::#state_ident as ::moku::State<#state_enum, #event>>::Superstates<'_>,
-                        ) -> Option<#state_enum> {
+                        ) -> ::moku::Next<#state_enum> {
                             match self {
-                                Self::None => None,
+                                Self::None => ::moku::Next::None,
                                 #(Self::#children(node) => {
                                     node.top_down_update_in_need(&mut #superstates::new(state, superstates))
                                 })*
@@ -658,10 +658,10 @@ impl Metadata {
                             state: &mut super::#state_ident,
                             superstates: &mut <super::#state_ident as ::moku::State<#state_enum, #event>>::Superstates<'_>,
                             in_update: bool,
-                        ) -> Option<#state_enum> {
+                        ) -> ::moku::Next<#state_enum> {
                             let old_state = core::mem::replace(self, Self::None);
                             match old_state {
-                                Self::None => None,
+                                Self::None => ::moku::Next::None,
                                 #(Self::#children(node) => node.exit(
                                         &mut #superstates::new(state, superstates),
                                         in_update,
@@ -675,11 +675,12 @@ impl Metadata {
                             state: &mut super::#state_ident,
                             superstates: &mut <super::#state_ident as ::moku::State<#state_enum, #event>>::Superstates<'_>,
                             in_update: bool,
+                            exact: bool,
                         ) -> ::moku::internal::TransitionResult<#state_enum> {
                             match self {
                                 Self::None => ::moku::internal::TransitionResult::MoveUp,
                                 #(Self::#children(node) => {
-                                    node.transition(target, &mut #superstates::new(state, superstates), in_update)
+                                    node.transition(target, &mut #superstates::new(state, superstates), in_update, exact)
                                 })*
                             }
                         }
@@ -690,7 +691,7 @@ impl Metadata {
                             state: &mut super::#state_ident,
                             superstates: &mut <super::#state_ident as ::moku::State<#state_enum, #event>>::Superstates<'_>,
                             in_update: bool,
-                        ) -> Option<#state_enum> {
+                        ) -> ::moku::Next<#state_enum> {
                             match target {
                                 #(
                                     #(#state_enum::#children_and_descendents)|* => {
@@ -700,9 +701,10 @@ impl Metadata {
                                         ) {
                                             ::moku::internal::NodeEntry::Node(node) => {
                                                 *self = Self::#children(node);
-                                                None
+                                                ::moku::Next::None
                                             }
-                                            ::moku::internal::NodeEntry::Target(new_target) => Some(new_target),
+                                            ::moku::internal::NodeEntry::Target(new_target) => ::moku::Next::Target(new_target),
+                                            ::moku::internal::NodeEntry::ExactTarget(new_target) => ::moku::Next::ExactTarget(new_target),
                                         }
                                     }
                                 )*

--- a/moku-macros/src/metadata.rs
+++ b/moku-macros/src/metadata.rs
@@ -322,6 +322,10 @@ impl Metadata {
                     self.top_node.transition(target, false);
                 }
 
+                fn transition_exact(&mut self, target: #state_enum) {
+                    self.top_node.transition_exact(target, false);
+                }
+
                 fn state(&self) -> #state_enum {
                     self.top_node.state()
                 }

--- a/moku-macros/src/metadata.rs
+++ b/moku-macros/src/metadata.rs
@@ -322,7 +322,7 @@ impl Metadata {
                     self.top_node.transition(target, false, false);
                 }
 
-                fn transition_exact(&mut self, target: #state_enum) {
+                fn exact_transition(&mut self, target: #state_enum) {
                     self.top_node.transition(target, false, true);
                 }
 

--- a/moku-macros/src/metadata.rs
+++ b/moku-macros/src/metadata.rs
@@ -725,7 +725,7 @@ impl Metadata {
                             superstates: &mut <super::#state_ident as ::moku::State<#state_enum, #event>>::Superstates<'_>,
                         ) -> ::moku::EventResponse<#state_enum> {
                             match self {
-                                Self::None => ::moku::EventResponse::Defer,
+                                Self::None => ::moku::EventResponse::Next(::moku::Next::None),
                                 #(Self::#children(node) => node.handle_event(
                                         event,
                                         &mut #superstates::new(state, superstates),

--- a/moku-macros/src/metadata.rs
+++ b/moku-macros/src/metadata.rs
@@ -319,11 +319,11 @@ impl Metadata {
                 }
 
                 fn transition(&mut self, target: #state_enum) {
-                    self.top_node.transition(target, false);
+                    self.top_node.transition(target, false, false);
                 }
 
                 fn transition_exact(&mut self, target: #state_enum) {
-                    self.top_node.transition_exact(target, false);
+                    self.top_node.transition(target, false, true);
                 }
 
                 fn state(&self) -> #state_enum {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1776,7 +1776,7 @@ pub mod internal {
                                 TransitionResult::MoveUp
                             }
                         }
-                        next @ _ => TransitionResult::Next(next),
+                        next => TransitionResult::Next(next),
                     }
                 }
                 res => res,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -361,7 +361,7 @@ where
     /// transition is made. To force re-entry of an active state, use
     /// [`StateMachine::exact_transition`].
     ///
-    /// Subject to interruption by short circuit transtions (from [`State::enter`] or [`State::exit`])
+    /// Subject to interruption by short circuit transitions (from [`State::enter`] or [`State::exit`])
     /// and initial transitions (from [`State::init`] or [`TopState::init`]).
     /// # Example
     /// ```
@@ -402,7 +402,7 @@ where
     /// active states.
     ///
     /// Makes the transition even if the target state is in the current active state hierarchy.
-    /// The state will re-initialized; [`State::enter`] and [`State::init`] will be called.
+    /// The state will be re-initialized; [`State::enter`] and [`State::init`] will be called.
     ///
     /// Subject to interruption by short circuit transtions (from [`State::enter`] or [`State::exit`])
     /// and initial transitions (from [`State::init`] or [`TopState::init`]).

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -29,19 +29,19 @@ mod basic {
     }
 
     impl TopState<BasicState> for Top {
-        fn init(&mut self) -> Option<BasicState> {
+        fn init(&mut self) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self) -> Option<BasicState> {
+        fn update(&mut self) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = self.update_order_acc;
             self.update_order_acc += 1;
             None
         }
 
-        fn top_down_update(&mut self) -> Option<BasicState> {
+        fn top_down_update(&mut self) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = self.update_order_acc;
             self.update_order_acc += 1;
@@ -68,19 +68,25 @@ mod basic {
 
     #[superstate(Top)]
     impl State<BasicState> for A {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BasicState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
             })
         }
 
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -90,14 +96,14 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> Option<BasicState> {
+        ) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
             None
         }
 
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<BasicState>> {
             self.exit.set(self.exit.get() + 1);
             None
         }
@@ -142,19 +148,25 @@ mod basic {
 
     #[superstate(Top)]
     impl State<BasicState> for B {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BasicState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
             })
         }
 
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -164,14 +176,14 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> Option<BasicState> {
+        ) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
             None
         }
 
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<BasicState>> {
             self.exit.set(self.exit.get() + 1);
             None
         }
@@ -196,19 +208,25 @@ mod basic {
 
     #[superstate(B)]
     impl State<BasicState> for BA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BasicState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
             })
         }
 
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -218,14 +236,14 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> Option<BasicState> {
+        ) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
             None
         }
 
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<BasicState>> {
             self.exit.set(self.exit.get() + 1);
             None
         }
@@ -250,19 +268,25 @@ mod basic {
 
     #[superstate(B)]
     impl State<BasicState> for BB {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BasicState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
             })
         }
 
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -272,14 +296,14 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> Option<BasicState> {
+        ) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
             None
         }
 
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<BasicState>> {
             self.exit.set(self.exit.get() + 1);
             None
         }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -597,10 +597,12 @@ fn self_transition() {
     assert_eq!(state.enter, 1);
     assert_eq!(state.exit_counter().get(), 0);
 
+    let a_exit = state.exit_counter();
+
     machine.exact_transition(TesterState::A);
     assert!(matches!(machine.state(), TesterState::A));
     let state: &A = machine.state_ref().unwrap();
-    assert_eq!(state.init, 2);
-    assert_eq!(state.enter, 2);
-    assert_eq!(state.exit_counter().get(), 1);
+    assert_eq!(state.init, 1);
+    assert_eq!(state.enter, 1);
+    assert_eq!(a_exit.get(), 1);
 }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -569,3 +569,38 @@ fn enter_init_exit() {
     assert_eq!(state.enter, 1);
     assert_eq!(state.init, 1);
 }
+
+#[test]
+fn self_transition() {
+    let mut machine = TesterMachineBuilder::new(Top::default()).build();
+    assert!(matches!(machine.state(), TesterState::Top));
+
+    assert_eq!(machine.top_ref().init, 1);
+
+    machine.transition(TesterState::Top);
+    assert_eq!(machine.top_ref().init, 1);
+
+    machine.exact_transition(TesterState::Top);
+    assert_eq!(machine.top_ref().init, 2);
+
+    machine.transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::A));
+    let state: &A = machine.state_ref().unwrap();
+    assert_eq!(state.init, 1);
+    assert_eq!(state.enter, 1);
+    assert_eq!(state.exit_counter().get(), 0);
+
+    machine.transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::A));
+    let state: &A = machine.state_ref().unwrap();
+    assert_eq!(state.init, 1);
+    assert_eq!(state.enter, 1);
+    assert_eq!(state.exit_counter().get(), 0);
+
+    machine.exact_transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::A));
+    let state: &A = machine.state_ref().unwrap();
+    assert_eq!(state.init, 2);
+    assert_eq!(state.enter, 2);
+    assert_eq!(state.exit_counter().get(), 1);
+}

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,14 +1,11 @@
 #![allow(clippy::upper_case_acronyms)]
 
-use basic::{
-    machine::{BasicMachineBuilder, BasicState, BASIC_STATE_CHART},
-    Top, A, B, BA, BB,
-};
 use moku::*;
 use test_log::test;
+use tester::{machine::*, *};
 
 #[state_machine]
-mod basic {
+mod tester {
     use std::{cell::Cell, rc::Rc};
 
     use moku::*;
@@ -16,7 +13,7 @@ mod basic {
     #[machine_module]
     pub mod machine {}
 
-    use machine::BasicState;
+    use machine::TesterState;
 
     #[derive(Default)]
     pub struct Top {
@@ -28,20 +25,20 @@ mod basic {
         pub update_order_acc: u8,
     }
 
-    impl TopState<BasicState> for Top {
-        fn init(&mut self) -> impl Into<Next<BasicState>> {
+    impl TopState<TesterState> for Top {
+        fn init(&mut self) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self) -> impl Into<Next<BasicState>> {
+        fn update(&mut self) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = self.update_order_acc;
             self.update_order_acc += 1;
             None
         }
 
-        fn top_down_update(&mut self) -> impl Into<Next<BasicState>> {
+        fn top_down_update(&mut self) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = self.update_order_acc;
             self.update_order_acc += 1;
@@ -67,8 +64,8 @@ mod basic {
     }
 
     #[superstate(Top)]
-    impl State<BasicState> for A {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
+    impl State<TesterState> for A {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
@@ -78,7 +75,7 @@ mod basic {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
@@ -86,7 +83,7 @@ mod basic {
         fn update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -96,14 +93,14 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
             None
         }
 
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<BasicState>> {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<TesterState>> {
             self.exit.set(self.exit.get() + 1);
             None
         }
@@ -112,22 +109,22 @@ mod basic {
     struct AA;
 
     #[superstate(A)]
-    impl State<BasicState> for AA {}
+    impl State<TesterState> for AA {}
 
     struct AAA;
 
     #[superstate(AA)]
-    impl State<BasicState> for AAA {}
+    impl State<TesterState> for AAA {}
 
     struct AB;
 
     #[superstate(A)]
-    impl State<BasicState> for AB {}
+    impl State<TesterState> for AB {}
 
     struct ABA;
 
     #[superstate(AB)]
-    impl State<BasicState> for ABA {}
+    impl State<TesterState> for ABA {}
 
     #[derive(Default)]
     pub struct B {
@@ -147,8 +144,8 @@ mod basic {
     }
 
     #[superstate(Top)]
-    impl State<BasicState> for B {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
+    impl State<TesterState> for B {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
@@ -158,7 +155,7 @@ mod basic {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
@@ -166,7 +163,7 @@ mod basic {
         fn update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -176,14 +173,14 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
             None
         }
 
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<BasicState>> {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<TesterState>> {
             self.exit.set(self.exit.get() + 1);
             None
         }
@@ -207,8 +204,8 @@ mod basic {
     }
 
     #[superstate(B)]
-    impl State<BasicState> for BA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
+    impl State<TesterState> for BA {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
@@ -218,7 +215,7 @@ mod basic {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
@@ -226,7 +223,7 @@ mod basic {
         fn update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -236,14 +233,14 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
             None
         }
 
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<BasicState>> {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<TesterState>> {
             self.exit.set(self.exit.get() + 1);
             None
         }
@@ -267,8 +264,8 @@ mod basic {
     }
 
     #[superstate(B)]
-    impl State<BasicState> for BB {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
+    impl State<TesterState> for BB {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
@@ -278,7 +275,7 @@ mod basic {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
@@ -286,7 +283,7 @@ mod basic {
         fn update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -296,14 +293,14 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
             None
         }
 
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<BasicState>> {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<TesterState>> {
             self.exit.set(self.exit.get() + 1);
             None
         }
@@ -313,7 +310,7 @@ mod basic {
 #[test]
 fn state_chart() {
     assert_eq!(
-        BASIC_STATE_CHART,
+        TESTER_STATE_CHART,
         "Top
 ├─ A
 │  ├─ AA
@@ -328,10 +325,10 @@ fn state_chart() {
 
 #[test]
 fn machine_name() {
-    let machine = BasicMachineBuilder::new(Top::default()).build();
-    assert_eq!(machine.name(), "Basic");
+    let machine = TesterMachineBuilder::new(Top::default()).build();
+    assert_eq!(machine.name(), "Tester");
 
-    let mut machine = BasicMachineBuilder::new(Top::default())
+    let mut machine = TesterMachineBuilder::new(Top::default())
         .name("Kantan".to_owned())
         .build();
     assert_eq!(machine.name(), "Kantan");
@@ -342,56 +339,56 @@ fn machine_name() {
 
 #[test]
 fn state_match() {
-    let mut machine = BasicMachineBuilder::new(Top::default()).build();
+    let mut machine = TesterMachineBuilder::new(Top::default()).build();
 
-    assert!(matches!(machine.state(), BasicState::Top));
+    assert!(matches!(machine.state(), TesterState::Top));
 
-    assert!(machine.state_matches(BasicState::Top));
-    assert!(!machine.state_matches(BasicState::A));
-    assert!(!machine.state_matches(BasicState::B));
-    assert!(!machine.state_matches(BasicState::BA));
-    assert!(!machine.state_matches(BasicState::BB));
+    assert!(machine.state_matches(TesterState::Top));
+    assert!(!machine.state_matches(TesterState::A));
+    assert!(!machine.state_matches(TesterState::B));
+    assert!(!machine.state_matches(TesterState::BA));
+    assert!(!machine.state_matches(TesterState::BB));
 
-    machine.transition(BasicState::A);
-    assert!(matches!(machine.state(), BasicState::A));
+    machine.transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::A));
 
-    assert!(machine.state_matches(BasicState::Top));
-    assert!(machine.state_matches(BasicState::A));
-    assert!(!machine.state_matches(BasicState::B));
-    assert!(!machine.state_matches(BasicState::BA));
-    assert!(!machine.state_matches(BasicState::BB));
+    assert!(machine.state_matches(TesterState::Top));
+    assert!(machine.state_matches(TesterState::A));
+    assert!(!machine.state_matches(TesterState::B));
+    assert!(!machine.state_matches(TesterState::BA));
+    assert!(!machine.state_matches(TesterState::BB));
 
-    machine.transition(BasicState::B);
-    assert!(matches!(machine.state(), BasicState::B));
+    machine.transition(TesterState::B);
+    assert!(matches!(machine.state(), TesterState::B));
 
-    assert!(machine.state_matches(BasicState::Top));
-    assert!(!machine.state_matches(BasicState::A));
-    assert!(machine.state_matches(BasicState::B));
-    assert!(!machine.state_matches(BasicState::BA));
-    assert!(!machine.state_matches(BasicState::BB));
+    assert!(machine.state_matches(TesterState::Top));
+    assert!(!machine.state_matches(TesterState::A));
+    assert!(machine.state_matches(TesterState::B));
+    assert!(!machine.state_matches(TesterState::BA));
+    assert!(!machine.state_matches(TesterState::BB));
 
-    machine.transition(BasicState::BA);
-    assert!(matches!(machine.state(), BasicState::BA));
+    machine.transition(TesterState::BA);
+    assert!(matches!(machine.state(), TesterState::BA));
 
-    assert!(machine.state_matches(BasicState::Top));
-    assert!(!machine.state_matches(BasicState::A));
-    assert!(machine.state_matches(BasicState::B));
-    assert!(machine.state_matches(BasicState::BA));
-    assert!(!machine.state_matches(BasicState::BB));
+    assert!(machine.state_matches(TesterState::Top));
+    assert!(!machine.state_matches(TesterState::A));
+    assert!(machine.state_matches(TesterState::B));
+    assert!(machine.state_matches(TesterState::BA));
+    assert!(!machine.state_matches(TesterState::BB));
 
-    machine.transition(BasicState::BB);
-    assert!(matches!(machine.state(), BasicState::BB));
+    machine.transition(TesterState::BB);
+    assert!(matches!(machine.state(), TesterState::BB));
 
-    assert!(machine.state_matches(BasicState::Top));
-    assert!(!machine.state_matches(BasicState::A));
-    assert!(machine.state_matches(BasicState::B));
-    assert!(!machine.state_matches(BasicState::BA));
-    assert!(machine.state_matches(BasicState::BB));
+    assert!(machine.state_matches(TesterState::Top));
+    assert!(!machine.state_matches(TesterState::A));
+    assert!(machine.state_matches(TesterState::B));
+    assert!(!machine.state_matches(TesterState::BA));
+    assert!(machine.state_matches(TesterState::BB));
 }
 
 #[test]
 fn state_refs() {
-    let mut machine = BasicMachineBuilder::new(Top::default()).build();
+    let mut machine = TesterMachineBuilder::new(Top::default()).build();
 
     assert_eq!(machine.top_ref().init, 1);
     machine.top_mut().access += 1;
@@ -412,7 +409,7 @@ fn state_refs() {
     let state: Option<&BB> = machine.state_ref();
     assert!(state.is_none());
 
-    machine.transition(BasicState::A);
+    machine.transition(TesterState::A);
 
     let state: Option<&Top> = machine.state_ref();
     assert!(state.is_some());
@@ -425,7 +422,7 @@ fn state_refs() {
     let state: Option<&BB> = machine.state_ref();
     assert!(state.is_none());
 
-    machine.transition(BasicState::A);
+    machine.transition(TesterState::A);
 
     let state: Option<&Top> = machine.state_ref();
     assert!(state.is_some());
@@ -438,7 +435,7 @@ fn state_refs() {
     let state: Option<&BB> = machine.state_ref();
     assert!(state.is_none());
 
-    machine.transition(BasicState::BA);
+    machine.transition(TesterState::BA);
 
     let state: Option<&Top> = machine.state_ref();
     assert!(state.is_some());
@@ -451,7 +448,7 @@ fn state_refs() {
     let state: Option<&BB> = machine.state_ref();
     assert!(state.is_none());
 
-    machine.transition(BasicState::BB);
+    machine.transition(TesterState::BB);
 
     let state: Option<&Top> = machine.state_ref();
     assert!(state.is_some());
@@ -467,8 +464,8 @@ fn state_refs() {
 
 #[test]
 fn update_order() {
-    let mut machine = BasicMachineBuilder::new(Top::default()).build();
-    machine.transition(BasicState::BA);
+    let mut machine = TesterMachineBuilder::new(Top::default()).build();
+    machine.transition(TesterState::BA);
 
     let top: &Top = machine.state_ref().unwrap();
     let bar: &B = machine.state_ref().unwrap();
@@ -523,13 +520,13 @@ fn update_order() {
 
 #[test]
 fn enter_init_exit() {
-    let mut machine = BasicMachineBuilder::new(Top::default()).build();
-    assert!(matches!(machine.state(), BasicState::Top));
+    let mut machine = TesterMachineBuilder::new(Top::default()).build();
+    assert!(matches!(machine.state(), TesterState::Top));
 
     assert_eq!(machine.top_ref().init, 1);
 
-    machine.transition(BasicState::BA);
-    assert!(matches!(machine.state(), BasicState::BA));
+    machine.transition(TesterState::BA);
+    assert!(matches!(machine.state(), TesterState::BA));
 
     assert_eq!(machine.top_ref().init, 1);
 
@@ -544,8 +541,8 @@ fn enter_init_exit() {
     let ba_exit = state.exit_counter();
     assert_eq!(ba_exit.get(), 0);
 
-    machine.transition(BasicState::BB);
-    assert!(matches!(machine.state(), BasicState::BB));
+    machine.transition(TesterState::BB);
+    assert!(matches!(machine.state(), TesterState::BB));
 
     assert_eq!(ba_exit.get(), 1);
 
@@ -560,8 +557,8 @@ fn enter_init_exit() {
     assert_eq!(state.enter, 1);
     assert_eq!(state.init, 1);
 
-    machine.transition(BasicState::B);
-    assert!(matches!(machine.state(), BasicState::BB));
+    machine.transition(TesterState::B);
+    assert!(matches!(machine.state(), TesterState::BB));
 
     let state: &B = machine.state_ref().unwrap();
     assert_eq!(state.enter, 1);

--- a/tests/compile_pass/foreign_struct_defs.rs
+++ b/tests/compile_pass/foreign_struct_defs.rs
@@ -23,7 +23,7 @@ mod blinky {
 
     #[superstate(Top)]
     impl State<BlinkyState, EventTy> for BottomTy {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BlinkyState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BlinkyState, Self> {
             StateEntry::State(Self {})
         }
     }
@@ -32,7 +32,7 @@ mod blinky {
 
     #[superstate(BottomTy)]
     impl State<BlinkyState, EventTy> for Under {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BlinkyState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BlinkyState, Self> {
             StateEntry::State(Self {})
         }
     }

--- a/tests/default_state_actions.rs
+++ b/tests/default_state_actions.rs
@@ -1,46 +1,43 @@
-use dft::{
-    machine::{DftMachineBuilder, DftState},
-    Top,
-};
 use moku::*;
 use test_log::test;
+use tester::{machine::*, *};
 
 #[state_machine]
-mod dft {
+mod tester {
     use moku::*;
 
     #[machine_module]
     pub mod machine {}
 
-    use machine::DftState;
+    use machine::TesterState;
 
     pub struct Top;
 
-    impl TopState<DftState> for Top {}
+    impl TopState<TesterState> for Top {}
 
     struct Foo;
 
     #[superstate(Top)]
-    impl State<DftState> for Foo {}
+    impl State<TesterState> for Foo {}
 }
 
 #[test]
 fn default_actions() {
-    let mut machine = DftMachineBuilder::new(Top).build();
-    assert!(matches!(machine.state(), DftState::Top));
+    let mut machine = TesterMachineBuilder::new(Top).build();
+    assert!(matches!(machine.state(), TesterState::Top));
 
     machine.update();
-    assert!(matches!(machine.state(), DftState::Top));
+    assert!(matches!(machine.state(), TesterState::Top));
 
     machine.top_down_update();
-    assert!(matches!(machine.state(), DftState::Top));
+    assert!(matches!(machine.state(), TesterState::Top));
 
-    machine.transition(DftState::Foo);
-    assert!(matches!(machine.state(), DftState::Foo));
+    machine.transition(TesterState::Foo);
+    assert!(matches!(machine.state(), TesterState::Foo));
 
     machine.update();
-    assert!(matches!(machine.state(), DftState::Foo));
+    assert!(matches!(machine.state(), TesterState::Foo));
 
     machine.top_down_update();
-    assert!(matches!(machine.state(), DftState::Foo));
+    assert!(matches!(machine.state(), TesterState::Foo));
 }

--- a/tests/events.rs
+++ b/tests/events.rs
@@ -35,7 +35,7 @@ mod event {
     pub struct Top;
 
     impl TopState<EventState, Event> for Top {
-        fn handle_event(&mut self, event: &Event) -> Option<EventState> {
+        fn handle_event(&mut self, event: &Event) -> impl Into<Next<EventState>> {
             match event {
                 Event::A => Some(EventState::Foo),
                 Event::B => Some(EventState::Bar),
@@ -60,7 +60,7 @@ mod event {
             &mut self,
             _event: &Event,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> EventResponse<EventState> {
+        ) -> impl Into<EventResponse<EventState>> {
             EventResponse::Drop
         }
     }
@@ -73,10 +73,10 @@ mod event {
             &mut self,
             event: &Event,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> EventResponse<EventState> {
+        ) -> impl Into<EventResponse<EventState>> {
             match event {
-                Event::C => EventResponse::Transition(EventState::Foo),
-                _ => EventResponse::Defer,
+                Event::C => Some(EventState::Foo),
+                _ => None,
             }
         }
     }
@@ -89,10 +89,10 @@ mod event {
             &mut self,
             event: &Event,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> EventResponse<EventState> {
+        ) -> impl Into<EventResponse<EventState>> {
             match event {
-                Event::A => EventResponse::Transition(EventState::Bar),
-                _ => EventResponse::Defer,
+                Event::A => Some(EventState::Bar),
+                _ => None,
             }
         }
     }

--- a/tests/exact_transition.rs
+++ b/tests/exact_transition.rs
@@ -1,0 +1,176 @@
+#![allow(clippy::upper_case_acronyms)]
+
+use moku::*;
+use test_log::test;
+use tester::{machine::*, *};
+
+#[state_machine]
+mod tester {
+    use moku::*;
+
+    #[machine_module]
+    pub mod machine {}
+    use machine::TesterState;
+
+    pub struct Top;
+    impl TopState<TesterState> for Top {}
+
+    struct A;
+    #[superstate(Top)]
+    impl State<TesterState> for A {}
+
+    struct AA;
+    #[superstate(A)]
+    impl State<TesterState> for AA {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
+            Self.into()
+        }
+
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<TesterState>> {
+            TesterState::A
+        }
+
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<TesterState>> {
+            TesterState::A
+        }
+
+        fn top_down_update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<TesterState>> {
+            TesterState::A
+        }
+
+        fn handle_event(
+            &mut self,
+            _event: &(),
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<EventResponse<TesterState>> {
+            TesterState::A
+        }
+
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<TesterState>> {
+            TesterState::Top
+        }
+    }
+
+    struct B;
+    #[superstate(Top)]
+    impl State<TesterState> for B {
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<TesterState>> {
+            Next::ExactTarget(TesterState::Top)
+        }
+
+        fn top_down_update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<TesterState>> {
+            Next::ExactTarget(TesterState::Top)
+        }
+
+        fn handle_event(
+            &mut self,
+            _event: &(),
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<EventResponse<TesterState>> {
+            Next::ExactTarget(TesterState::Top)
+        }
+
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<TesterState>> {
+            Next::ExactTarget(TesterState::Top)
+        }
+    }
+
+    struct BA;
+    #[superstate(B)]
+    impl State<TesterState> for BA {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
+            StateEntry::ExactTarget(TesterState::Top)
+        }
+    }
+
+    struct BB;
+    #[superstate(B)]
+    impl State<TesterState> for BB {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<TesterState>> {
+            Next::ExactTarget(TesterState::Top)
+        }
+    }
+}
+
+#[test]
+fn state_machine() {
+    let mut machine = TesterMachineBuilder::new(Top {}).build();
+
+    machine.transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::A));
+
+    machine.transition(TesterState::Top);
+    assert!(matches!(machine.state(), TesterState::A));
+
+    machine.exact_transition(TesterState::Top);
+    assert!(matches!(machine.state(), TesterState::Top));
+}
+
+#[test]
+fn normal_transition() {
+    let mut machine = TesterMachineBuilder::new(Top {}).build();
+
+    machine.transition(TesterState::AA);
+    assert!(matches!(machine.state(), TesterState::AA));
+
+    machine.update();
+    assert!(matches!(machine.state(), TesterState::AA));
+
+    machine.top_down_update();
+    assert!(matches!(machine.state(), TesterState::AA));
+
+    machine.handle_event(&());
+    assert!(matches!(machine.state(), TesterState::AA));
+
+    machine.exact_transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::A));
+}
+
+#[test]
+fn exact_transition() {
+    let mut machine = TesterMachineBuilder::new(Top {}).build();
+
+    machine.transition(TesterState::B);
+    assert!(matches!(machine.state(), TesterState::B));
+    machine.update();
+    assert!(matches!(machine.state(), TesterState::Top));
+
+    machine.transition(TesterState::B);
+    assert!(matches!(machine.state(), TesterState::B));
+    machine.top_down_update();
+    assert!(matches!(machine.state(), TesterState::Top));
+
+    machine.transition(TesterState::B);
+    assert!(matches!(machine.state(), TesterState::B));
+    machine.handle_event(&());
+    assert!(matches!(machine.state(), TesterState::Top));
+
+    machine.transition(TesterState::B);
+    assert!(matches!(machine.state(), TesterState::B));
+    machine.exact_transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::Top));
+
+    machine.transition(TesterState::BA);
+    assert!(matches!(machine.state(), TesterState::Top));
+
+    machine.transition(TesterState::BB);
+    assert!(matches!(machine.state(), TesterState::Top));
+}

--- a/tests/no-std/src/lib.rs
+++ b/tests/no-std/src/lib.rs
@@ -30,19 +30,19 @@ mod basic {
     }
 
     impl TopState<BasicState> for Top {
-        fn init(&mut self) -> Option<BasicState> {
+        fn init(&mut self) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self) -> Option<BasicState> {
+        fn update(&mut self) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = self.update_order_acc;
             self.update_order_acc += 1;
             None
         }
 
-        fn top_down_update(&mut self) -> Option<BasicState> {
+        fn top_down_update(&mut self) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = self.update_order_acc;
             self.update_order_acc += 1;
@@ -62,19 +62,25 @@ mod basic {
 
     #[superstate(Top)]
     impl State<BasicState> for A {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BasicState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
             })
         }
 
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -84,7 +90,7 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> Option<BasicState> {
+        ) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -124,19 +130,25 @@ mod basic {
 
     #[superstate(Top)]
     impl State<BasicState> for B {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BasicState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
             })
         }
 
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -146,7 +158,7 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> Option<BasicState> {
+        ) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -166,19 +178,25 @@ mod basic {
 
     #[superstate(B)]
     impl State<BasicState> for BA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BasicState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
             })
         }
 
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -188,7 +206,7 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> Option<BasicState> {
+        ) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -208,19 +226,25 @@ mod basic {
 
     #[superstate(B)]
     impl State<BasicState> for BB {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, BasicState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
             })
         }
 
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self, superstates: &mut Self::Superstates<'_>) -> Option<BasicState> {
+        fn update(
+            &mut self,
+            superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<BasicState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -230,7 +254,7 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> Option<BasicState> {
+        ) -> impl Into<Next<BasicState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;

--- a/tests/no-std/src/lib.rs
+++ b/tests/no-std/src/lib.rs
@@ -1,4 +1,4 @@
-// This is a copy of the /tests/basic.rs tests but with the std feature disabled and enforcing no_std.
+// This is a copy of the /tests/tester.rs tests but with the std feature disabled and enforcing no_std.
 //
 // These tests will fail if run with `cargo test --all` at the workspace root, due to a limitation of
 // cargo that is well described here: https://github.com/rust-lang/cargo/issues/10636
@@ -11,13 +11,13 @@ extern crate moku;
 use moku::*;
 
 #[state_machine]
-mod basic {
+mod tester {
     use moku::*;
 
     #[machine_module]
     pub mod machine {}
 
-    use machine::BasicState;
+    use machine::TesterState;
 
     #[derive(Default)]
     pub struct Top {
@@ -29,20 +29,20 @@ mod basic {
         pub update_order_acc: u8,
     }
 
-    impl TopState<BasicState> for Top {
-        fn init(&mut self) -> impl Into<Next<BasicState>> {
+    impl TopState<TesterState> for Top {
+        fn init(&mut self) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
 
-        fn update(&mut self) -> impl Into<Next<BasicState>> {
+        fn update(&mut self) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = self.update_order_acc;
             self.update_order_acc += 1;
             None
         }
 
-        fn top_down_update(&mut self) -> impl Into<Next<BasicState>> {
+        fn top_down_update(&mut self) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = self.update_order_acc;
             self.update_order_acc += 1;
@@ -61,8 +61,8 @@ mod basic {
     }
 
     #[superstate(Top)]
-    impl State<BasicState> for A {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
+    impl State<TesterState> for A {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
@@ -72,7 +72,7 @@ mod basic {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
@@ -80,7 +80,7 @@ mod basic {
         fn update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -90,7 +90,7 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -101,22 +101,22 @@ mod basic {
     struct AA;
 
     #[superstate(A)]
-    impl State<BasicState> for AA {}
+    impl State<TesterState> for AA {}
 
     struct AAA;
 
     #[superstate(AA)]
-    impl State<BasicState> for AAA {}
+    impl State<TesterState> for AAA {}
 
     struct AB;
 
     #[superstate(A)]
-    impl State<BasicState> for AB {}
+    impl State<TesterState> for AB {}
 
     struct ABA;
 
     #[superstate(AB)]
-    impl State<BasicState> for ABA {}
+    impl State<TesterState> for ABA {}
 
     #[derive(Default)]
     pub struct B {
@@ -129,8 +129,8 @@ mod basic {
     }
 
     #[superstate(Top)]
-    impl State<BasicState> for B {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
+    impl State<TesterState> for B {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
@@ -140,7 +140,7 @@ mod basic {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
@@ -148,7 +148,7 @@ mod basic {
         fn update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -158,7 +158,7 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -177,8 +177,8 @@ mod basic {
     }
 
     #[superstate(B)]
-    impl State<BasicState> for BA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
+    impl State<TesterState> for BA {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
@@ -188,7 +188,7 @@ mod basic {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
@@ -196,7 +196,7 @@ mod basic {
         fn update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -206,7 +206,7 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -225,8 +225,8 @@ mod basic {
     }
 
     #[superstate(B)]
-    impl State<BasicState> for BB {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<BasicState, Self> {
+    impl State<TesterState> for BB {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 enter: 1,
                 ..Default::default()
@@ -236,7 +236,7 @@ mod basic {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.init += 1;
             None
         }
@@ -244,7 +244,7 @@ mod basic {
         fn update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -254,7 +254,7 @@ mod basic {
         fn top_down_update(
             &mut self,
             superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<BasicState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             self.update_order = superstates.top.update_order_acc;
             superstates.top.update_order_acc += 1;
@@ -266,16 +266,12 @@ mod basic {
 #[cfg(test)]
 mod tests {
     use super::moku::*;
-
-    use super::basic::{
-        machine::{BasicMachineBuilder, BasicState, BASIC_STATE_CHART},
-        Top, A, B, BA, BB,
-    };
+    use super::tester::{machine::*, *};
 
     #[test]
     fn state_chart() {
         assert_eq!(
-            BASIC_STATE_CHART,
+            TESTER_STATE_CHART,
             "Top
 ├─ A
 │  ├─ AA
@@ -290,62 +286,62 @@ mod tests {
 
     #[test]
     fn machine_name() {
-        let machine = BasicMachineBuilder::new(Top::default()).build();
-        assert_eq!(machine.name(), "Basic");
+        let machine = TesterMachineBuilder::new(Top::default()).build();
+        assert_eq!(machine.name(), "Tester");
     }
 
     #[test]
     fn state_match() {
-        let mut machine = BasicMachineBuilder::new(Top::default()).build();
+        let mut machine = TesterMachineBuilder::new(Top::default()).build();
 
-        assert!(matches!(machine.state(), BasicState::Top));
+        assert!(matches!(machine.state(), TesterState::Top));
 
-        assert!(machine.state_matches(BasicState::Top));
-        assert!(!machine.state_matches(BasicState::A));
-        assert!(!machine.state_matches(BasicState::B));
-        assert!(!machine.state_matches(BasicState::BA));
-        assert!(!machine.state_matches(BasicState::BB));
+        assert!(machine.state_matches(TesterState::Top));
+        assert!(!machine.state_matches(TesterState::A));
+        assert!(!machine.state_matches(TesterState::B));
+        assert!(!machine.state_matches(TesterState::BA));
+        assert!(!machine.state_matches(TesterState::BB));
 
-        machine.transition(BasicState::A);
-        assert!(matches!(machine.state(), BasicState::A));
+        machine.transition(TesterState::A);
+        assert!(matches!(machine.state(), TesterState::A));
 
-        assert!(machine.state_matches(BasicState::Top));
-        assert!(machine.state_matches(BasicState::A));
-        assert!(!machine.state_matches(BasicState::B));
-        assert!(!machine.state_matches(BasicState::BA));
-        assert!(!machine.state_matches(BasicState::BB));
+        assert!(machine.state_matches(TesterState::Top));
+        assert!(machine.state_matches(TesterState::A));
+        assert!(!machine.state_matches(TesterState::B));
+        assert!(!machine.state_matches(TesterState::BA));
+        assert!(!machine.state_matches(TesterState::BB));
 
-        machine.transition(BasicState::B);
-        assert!(matches!(machine.state(), BasicState::B));
+        machine.transition(TesterState::B);
+        assert!(matches!(machine.state(), TesterState::B));
 
-        assert!(machine.state_matches(BasicState::Top));
-        assert!(!machine.state_matches(BasicState::A));
-        assert!(machine.state_matches(BasicState::B));
-        assert!(!machine.state_matches(BasicState::BA));
-        assert!(!machine.state_matches(BasicState::BB));
+        assert!(machine.state_matches(TesterState::Top));
+        assert!(!machine.state_matches(TesterState::A));
+        assert!(machine.state_matches(TesterState::B));
+        assert!(!machine.state_matches(TesterState::BA));
+        assert!(!machine.state_matches(TesterState::BB));
 
-        machine.transition(BasicState::BA);
-        assert!(matches!(machine.state(), BasicState::BA));
+        machine.transition(TesterState::BA);
+        assert!(matches!(machine.state(), TesterState::BA));
 
-        assert!(machine.state_matches(BasicState::Top));
-        assert!(!machine.state_matches(BasicState::A));
-        assert!(machine.state_matches(BasicState::B));
-        assert!(machine.state_matches(BasicState::BA));
-        assert!(!machine.state_matches(BasicState::BB));
+        assert!(machine.state_matches(TesterState::Top));
+        assert!(!machine.state_matches(TesterState::A));
+        assert!(machine.state_matches(TesterState::B));
+        assert!(machine.state_matches(TesterState::BA));
+        assert!(!machine.state_matches(TesterState::BB));
 
-        machine.transition(BasicState::BB);
-        assert!(matches!(machine.state(), BasicState::BB));
+        machine.transition(TesterState::BB);
+        assert!(matches!(machine.state(), TesterState::BB));
 
-        assert!(machine.state_matches(BasicState::Top));
-        assert!(!machine.state_matches(BasicState::A));
-        assert!(machine.state_matches(BasicState::B));
-        assert!(!machine.state_matches(BasicState::BA));
-        assert!(machine.state_matches(BasicState::BB));
+        assert!(machine.state_matches(TesterState::Top));
+        assert!(!machine.state_matches(TesterState::A));
+        assert!(machine.state_matches(TesterState::B));
+        assert!(!machine.state_matches(TesterState::BA));
+        assert!(machine.state_matches(TesterState::BB));
     }
 
     #[test]
     fn state_refs() {
-        let mut machine = BasicMachineBuilder::new(Top::default()).build();
+        let mut machine = TesterMachineBuilder::new(Top::default()).build();
 
         assert_eq!(machine.top_ref().init, 1);
         machine.top_mut().access += 1;
@@ -366,7 +362,7 @@ mod tests {
         let state: Option<&BB> = machine.state_ref();
         assert!(state.is_none());
 
-        machine.transition(BasicState::A);
+        machine.transition(TesterState::A);
 
         let state: Option<&Top> = machine.state_ref();
         assert!(state.is_some());
@@ -379,7 +375,7 @@ mod tests {
         let state: Option<&BB> = machine.state_ref();
         assert!(state.is_none());
 
-        machine.transition(BasicState::A);
+        machine.transition(TesterState::A);
 
         let state: Option<&Top> = machine.state_ref();
         assert!(state.is_some());
@@ -392,7 +388,7 @@ mod tests {
         let state: Option<&BB> = machine.state_ref();
         assert!(state.is_none());
 
-        machine.transition(BasicState::BA);
+        machine.transition(TesterState::BA);
 
         let state: Option<&Top> = machine.state_ref();
         assert!(state.is_some());
@@ -405,7 +401,7 @@ mod tests {
         let state: Option<&BB> = machine.state_ref();
         assert!(state.is_none());
 
-        machine.transition(BasicState::BB);
+        machine.transition(TesterState::BB);
 
         let state: Option<&Top> = machine.state_ref();
         assert!(state.is_some());
@@ -421,8 +417,8 @@ mod tests {
 
     #[test]
     fn update_order() {
-        let mut machine = BasicMachineBuilder::new(Top::default()).build();
-        machine.transition(BasicState::BA);
+        let mut machine = TesterMachineBuilder::new(Top::default()).build();
+        machine.transition(TesterState::BA);
 
         let top: &Top = machine.state_ref().unwrap();
         let bar: &B = machine.state_ref().unwrap();
@@ -477,13 +473,13 @@ mod tests {
 
     #[test]
     fn enter_init_exit() {
-        let mut machine = BasicMachineBuilder::new(Top::default()).build();
-        assert!(matches!(machine.state(), BasicState::Top));
+        let mut machine = TesterMachineBuilder::new(Top::default()).build();
+        assert!(matches!(machine.state(), TesterState::Top));
 
         assert_eq!(machine.top_ref().init, 1);
 
-        machine.transition(BasicState::BA);
-        assert!(matches!(machine.state(), BasicState::BA));
+        machine.transition(TesterState::BA);
+        assert!(matches!(machine.state(), TesterState::BA));
 
         assert_eq!(machine.top_ref().init, 1);
 
@@ -495,8 +491,8 @@ mod tests {
         assert_eq!(state.enter, 1);
         assert_eq!(state.init, 1);
 
-        machine.transition(BasicState::BB);
-        assert!(matches!(machine.state(), BasicState::BB));
+        machine.transition(TesterState::BB);
+        assert!(matches!(machine.state(), TesterState::BB));
 
         assert_eq!(machine.top_ref().init, 1);
 
@@ -508,8 +504,8 @@ mod tests {
         assert_eq!(state.enter, 1);
         assert_eq!(state.init, 1);
 
-        machine.transition(BasicState::B);
-        assert!(matches!(machine.state(), BasicState::BB));
+        machine.transition(TesterState::B);
+        assert!(matches!(machine.state(), TesterState::BB));
 
         let state: &B = machine.state_ref().unwrap();
         assert_eq!(state.enter, 1);

--- a/tests/state_transitions.rs
+++ b/tests/state_transitions.rs
@@ -22,7 +22,10 @@ mod state_trans {
 
     #[superstate(Top)]
     impl State<StateTransState> for A {
-        fn init(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<StateTransState> {
+        fn init(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<StateTransState>> {
             Some(StateTransState::B)
         }
     }
@@ -31,7 +34,10 @@ mod state_trans {
 
     #[superstate(Top)]
     impl State<StateTransState> for B {
-        fn update(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<StateTransState> {
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<StateTransState>> {
             Some(StateTransState::C)
         }
     }
@@ -43,7 +49,7 @@ mod state_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> Option<StateTransState> {
+        ) -> impl Into<Next<StateTransState>> {
             Some(StateTransState::D)
         }
     }
@@ -52,7 +58,10 @@ mod state_trans {
 
     #[superstate(Top)]
     impl State<StateTransState> for D {
-        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> Option<StateTransState> {
+        fn exit(
+            self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<StateTransState>> {
             Some(StateTransState::E)
         }
     }
@@ -66,8 +75,8 @@ mod state_trans {
 
     #[superstate(Top)]
     impl State<StateTransState> for F {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, StateTransState> {
-            StateEntry::Transition(StateTransState::Top)
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<StateTransState, Self> {
+            StateEntry::Target(StateTransState::Top)
         }
     }
 }

--- a/tests/state_transitions.rs
+++ b/tests/state_transitions.rs
@@ -1,82 +1,76 @@
 use moku::*;
-use state_trans::{
-    machine::{StateTransMachineBuilder, StateTransState, STATE_TRANS_STATE_CHART},
-    Top,
-};
 use test_log::test;
+use tester::{machine::*, *};
 
 #[state_machine]
-mod state_trans {
+mod tester {
     use moku::*;
 
     #[machine_module]
     pub mod machine {}
 
-    use machine::StateTransState;
+    use machine::TesterState;
 
     pub struct Top;
 
-    impl TopState<StateTransState> for Top {}
+    impl TopState<TesterState> for Top {}
 
     struct A;
 
     #[superstate(Top)]
-    impl State<StateTransState> for A {
+    impl State<TesterState> for A {
         fn init(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<StateTransState>> {
-            Some(StateTransState::B)
+        ) -> impl Into<Next<TesterState>> {
+            Some(TesterState::B)
         }
     }
 
     struct B;
 
     #[superstate(Top)]
-    impl State<StateTransState> for B {
+    impl State<TesterState> for B {
         fn update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<StateTransState>> {
-            Some(StateTransState::C)
+        ) -> impl Into<Next<TesterState>> {
+            Some(TesterState::C)
         }
     }
 
     struct C;
 
     #[superstate(Top)]
-    impl State<StateTransState> for C {
+    impl State<TesterState> for C {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<StateTransState>> {
-            Some(StateTransState::D)
+        ) -> impl Into<Next<TesterState>> {
+            Some(TesterState::D)
         }
     }
 
     struct D;
 
     #[superstate(Top)]
-    impl State<StateTransState> for D {
-        fn exit(
-            self,
-            _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<StateTransState>> {
-            Some(StateTransState::E)
+    impl State<TesterState> for D {
+        fn exit(self, _superstates: &mut Self::Superstates<'_>) -> impl Into<Next<TesterState>> {
+            Some(TesterState::E)
         }
     }
 
     struct E;
 
     #[superstate(Top)]
-    impl State<StateTransState> for E {}
+    impl State<TesterState> for E {}
 
     struct F;
 
     #[superstate(Top)]
-    impl State<StateTransState> for F {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<StateTransState, Self> {
-            StateEntry::Target(StateTransState::Top)
+    impl State<TesterState> for F {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
+            StateEntry::Target(TesterState::Top)
         }
     }
 }
@@ -84,7 +78,7 @@ mod state_trans {
 #[test]
 fn state_chart() {
     assert_eq!(
-        STATE_TRANS_STATE_CHART,
+        TESTER_STATE_CHART,
         "Top
 ├─ A
 ├─ B
@@ -97,38 +91,38 @@ fn state_chart() {
 
 #[test]
 fn init() {
-    let mut machine = StateTransMachineBuilder::new(Top).build();
-    machine.transition(StateTransState::A);
-    assert!(matches!(machine.state(), StateTransState::B));
+    let mut machine = TesterMachineBuilder::new(Top).build();
+    machine.transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::B));
 }
 
 #[test]
 fn update() {
-    let mut machine = StateTransMachineBuilder::new(Top).build();
-    machine.transition(StateTransState::B);
+    let mut machine = TesterMachineBuilder::new(Top).build();
+    machine.transition(TesterState::B);
     machine.update();
-    assert!(matches!(machine.state(), StateTransState::C));
+    assert!(matches!(machine.state(), TesterState::C));
 }
 
 #[test]
 fn top_down_update() {
-    let mut machine = StateTransMachineBuilder::new(Top).build();
-    machine.transition(StateTransState::C);
+    let mut machine = TesterMachineBuilder::new(Top).build();
+    machine.transition(TesterState::C);
     machine.top_down_update();
-    assert!(matches!(machine.state(), StateTransState::D));
+    assert!(matches!(machine.state(), TesterState::D));
 }
 
 #[test]
 fn exit() {
-    let mut machine = StateTransMachineBuilder::new(Top).build();
-    machine.transition(StateTransState::D);
-    machine.transition(StateTransState::A);
-    assert!(matches!(machine.state(), StateTransState::E));
+    let mut machine = TesterMachineBuilder::new(Top).build();
+    machine.transition(TesterState::D);
+    machine.transition(TesterState::A);
+    assert!(matches!(machine.state(), TesterState::E));
 }
 
 #[test]
 fn enter() {
-    let mut machine = StateTransMachineBuilder::new(Top).build();
-    machine.transition(StateTransState::F);
-    assert!(matches!(machine.state(), StateTransState::Top));
+    let mut machine = TesterMachineBuilder::new(Top).build();
+    machine.transition(TesterState::F);
+    assert!(matches!(machine.state(), TesterState::Top));
 }

--- a/tests/top_transitions.rs
+++ b/tests/top_transitions.rs
@@ -1,55 +1,52 @@
 use moku::*;
 use test_log::test;
-use top_trans::{
-    machine::{TopTransMachineBuilder, TopTransState, TOP_TRANS_STATE_CHART},
-    Top,
-};
+use tester::{machine::*, *};
 
 #[state_machine]
-mod top_trans {
+mod tester {
     use moku::*;
 
     #[machine_module]
     pub mod machine {}
 
-    use machine::TopTransState;
+    use machine::TesterState;
 
     pub struct Top;
 
-    impl TopState<TopTransState> for Top {
-        fn init(&mut self) -> impl Into<Next<TopTransState>> {
-            Some(TopTransState::A)
+    impl TopState<TesterState> for Top {
+        fn init(&mut self) -> impl Into<Next<TesterState>> {
+            Some(TesterState::A)
         }
 
-        fn update(&mut self) -> impl Into<Next<TopTransState>> {
-            Some(TopTransState::B)
+        fn update(&mut self) -> impl Into<Next<TesterState>> {
+            Some(TesterState::B)
         }
 
-        fn top_down_update(&mut self) -> impl Into<Next<TopTransState>> {
-            Some(TopTransState::C)
+        fn top_down_update(&mut self) -> impl Into<Next<TesterState>> {
+            Some(TesterState::C)
         }
     }
 
     struct A;
 
     #[superstate(Top)]
-    impl State<TopTransState> for A {}
+    impl State<TesterState> for A {}
 
     struct B;
 
     #[superstate(Top)]
-    impl State<TopTransState> for B {}
+    impl State<TesterState> for B {}
 
     struct C;
 
     #[superstate(Top)]
-    impl State<TopTransState> for C {}
+    impl State<TesterState> for C {}
 }
 
 #[test]
 fn state_chart() {
     assert_eq!(
-        TOP_TRANS_STATE_CHART,
+        TESTER_STATE_CHART,
         "Top
 ├─ A
 ├─ B
@@ -59,20 +56,20 @@ fn state_chart() {
 
 #[test]
 fn init() {
-    let machine = TopTransMachineBuilder::new(Top).build();
-    assert!(matches!(machine.state(), TopTransState::A));
+    let machine = TesterMachineBuilder::new(Top).build();
+    assert!(matches!(machine.state(), TesterState::A));
 }
 
 #[test]
 fn update() {
-    let mut machine = TopTransMachineBuilder::new(Top).build();
+    let mut machine = TesterMachineBuilder::new(Top).build();
     machine.update();
-    assert!(matches!(machine.state(), TopTransState::B));
+    assert!(matches!(machine.state(), TesterState::B));
 }
 
 #[test]
 fn top_down_update() {
-    let mut machine = TopTransMachineBuilder::new(Top).build();
+    let mut machine = TesterMachineBuilder::new(Top).build();
     machine.top_down_update();
-    assert!(matches!(machine.state(), TopTransState::C));
+    assert!(matches!(machine.state(), TesterState::C));
 }

--- a/tests/top_transitions.rs
+++ b/tests/top_transitions.rs
@@ -17,15 +17,15 @@ mod top_trans {
     pub struct Top;
 
     impl TopState<TopTransState> for Top {
-        fn init(&mut self) -> Option<TopTransState> {
+        fn init(&mut self) -> impl Into<Next<TopTransState>> {
             Some(TopTransState::A)
         }
 
-        fn update(&mut self) -> Option<TopTransState> {
+        fn update(&mut self) -> impl Into<Next<TopTransState>> {
             Some(TopTransState::B)
         }
 
-        fn top_down_update(&mut self) -> Option<TopTransState> {
+        fn top_down_update(&mut self) -> impl Into<Next<TopTransState>> {
             Some(TopTransState::C)
         }
     }

--- a/tests/update_transitions.rs
+++ b/tests/update_transitions.rs
@@ -20,12 +20,12 @@ mod update_trans {
     }
 
     impl TopState<UpdateTransState> for Top {
-        fn update(&mut self) -> Option<UpdateTransState> {
+        fn update(&mut self) -> impl Into<Next<UpdateTransState>> {
             self.update += 1;
             None
         }
 
-        fn top_down_update(&mut self) -> Option<UpdateTransState> {
+        fn top_down_update(&mut self) -> impl Into<Next<UpdateTransState>> {
             self.top_down_update += 1;
             None
         }
@@ -38,14 +38,17 @@ mod update_trans {
 
     #[superstate(Top)]
     impl State<UpdateTransState> for A {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, UpdateTransState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
             })
         }
 
-        fn update(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<UpdateTransState> {
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<UpdateTransState>> {
             self.update += 1;
             Some(UpdateTransState::BA)
         }
@@ -53,7 +56,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> Option<UpdateTransState> {
+        ) -> impl Into<Next<UpdateTransState>> {
             self.top_down_update += 1;
             Some(UpdateTransState::BA)
         }
@@ -66,14 +69,17 @@ mod update_trans {
 
     #[superstate(A)]
     impl State<UpdateTransState> for AA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, UpdateTransState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
             })
         }
 
-        fn update(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<UpdateTransState> {
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<UpdateTransState>> {
             self.update += 1;
             None
         }
@@ -81,7 +87,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> Option<UpdateTransState> {
+        ) -> impl Into<Next<UpdateTransState>> {
             self.top_down_update += 1;
             None
         }
@@ -94,14 +100,17 @@ mod update_trans {
 
     #[superstate(Top)]
     impl State<UpdateTransState> for B {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, UpdateTransState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
             })
         }
 
-        fn update(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<UpdateTransState> {
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<UpdateTransState>> {
             self.update += 1;
             Some(UpdateTransState::BA)
         }
@@ -109,7 +118,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> Option<UpdateTransState> {
+        ) -> impl Into<Next<UpdateTransState>> {
             self.top_down_update += 1;
             Some(UpdateTransState::BA)
         }
@@ -122,14 +131,17 @@ mod update_trans {
 
     #[superstate(B)]
     impl State<UpdateTransState> for BA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, UpdateTransState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
             })
         }
 
-        fn update(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<UpdateTransState> {
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<UpdateTransState>> {
             self.update += 1;
             None
         }
@@ -137,7 +149,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> Option<UpdateTransState> {
+        ) -> impl Into<Next<UpdateTransState>> {
             self.top_down_update += 1;
             None
         }
@@ -150,14 +162,17 @@ mod update_trans {
 
     #[superstate(B)]
     impl State<UpdateTransState> for BB {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, UpdateTransState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
             })
         }
 
-        fn update(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<UpdateTransState> {
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<UpdateTransState>> {
             self.update += 1;
             None
         }
@@ -165,7 +180,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> Option<UpdateTransState> {
+        ) -> impl Into<Next<UpdateTransState>> {
             self.top_down_update += 1;
             None
         }
@@ -178,14 +193,17 @@ mod update_trans {
 
     #[superstate(BB)]
     impl State<UpdateTransState> for BBA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<Self, UpdateTransState> {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
             })
         }
 
-        fn update(&mut self, _superstates: &mut Self::Superstates<'_>) -> Option<UpdateTransState> {
+        fn update(
+            &mut self,
+            _superstates: &mut Self::Superstates<'_>,
+        ) -> impl Into<Next<UpdateTransState>> {
             self.update += 1;
             Some(UpdateTransState::BA)
         }
@@ -193,7 +211,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> Option<UpdateTransState> {
+        ) -> impl Into<Next<UpdateTransState>> {
             self.top_down_update += 1;
             Some(UpdateTransState::BA)
         }

--- a/tests/update_transitions.rs
+++ b/tests/update_transitions.rs
@@ -2,30 +2,29 @@
 
 use moku::*;
 use test_log::test;
-use update_trans::machine::*;
-use update_trans::*;
+use tester::{machine::*, *};
 
 #[state_machine]
-mod update_trans {
+mod tester {
     use moku::*;
 
     #[machine_module]
     pub mod machine {}
 
-    use machine::UpdateTransState;
+    use machine::TesterState;
 
     pub struct Top {
         pub update: u8,
         pub top_down_update: u8,
     }
 
-    impl TopState<UpdateTransState> for Top {
-        fn update(&mut self) -> impl Into<Next<UpdateTransState>> {
+    impl TopState<TesterState> for Top {
+        fn update(&mut self) -> impl Into<Next<TesterState>> {
             self.update += 1;
             None
         }
 
-        fn top_down_update(&mut self) -> impl Into<Next<UpdateTransState>> {
+        fn top_down_update(&mut self) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             None
         }
@@ -37,8 +36,8 @@ mod update_trans {
     }
 
     #[superstate(Top)]
-    impl State<UpdateTransState> for A {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
+    impl State<TesterState> for A {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
@@ -48,17 +47,17 @@ mod update_trans {
         fn update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
-            Some(UpdateTransState::BA)
+            Some(TesterState::BA)
         }
 
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
-            Some(UpdateTransState::BA)
+            Some(TesterState::BA)
         }
     }
 
@@ -68,8 +67,8 @@ mod update_trans {
     }
 
     #[superstate(A)]
-    impl State<UpdateTransState> for AA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
+    impl State<TesterState> for AA {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
@@ -79,7 +78,7 @@ mod update_trans {
         fn update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             None
         }
@@ -87,7 +86,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             None
         }
@@ -99,8 +98,8 @@ mod update_trans {
     }
 
     #[superstate(Top)]
-    impl State<UpdateTransState> for B {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
+    impl State<TesterState> for B {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
@@ -110,17 +109,17 @@ mod update_trans {
         fn update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
-            Some(UpdateTransState::BA)
+            Some(TesterState::BA)
         }
 
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
-            Some(UpdateTransState::BA)
+            Some(TesterState::BA)
         }
     }
 
@@ -130,8 +129,8 @@ mod update_trans {
     }
 
     #[superstate(B)]
-    impl State<UpdateTransState> for BA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
+    impl State<TesterState> for BA {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
@@ -141,7 +140,7 @@ mod update_trans {
         fn update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             None
         }
@@ -149,7 +148,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             None
         }
@@ -161,8 +160,8 @@ mod update_trans {
     }
 
     #[superstate(B)]
-    impl State<UpdateTransState> for BB {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
+    impl State<TesterState> for BB {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
@@ -172,7 +171,7 @@ mod update_trans {
         fn update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
             None
         }
@@ -180,7 +179,7 @@ mod update_trans {
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
             None
         }
@@ -192,8 +191,8 @@ mod update_trans {
     }
 
     #[superstate(BB)]
-    impl State<UpdateTransState> for BBA {
-        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<UpdateTransState, Self> {
+    impl State<TesterState> for BBA {
+        fn enter(_superstates: &mut Self::Superstates<'_>) -> StateEntry<TesterState, Self> {
             StateEntry::State(Self {
                 update: 0,
                 top_down_update: 0,
@@ -203,17 +202,17 @@ mod update_trans {
         fn update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.update += 1;
-            Some(UpdateTransState::BA)
+            Some(TesterState::BA)
         }
 
         fn top_down_update(
             &mut self,
             _superstates: &mut Self::Superstates<'_>,
-        ) -> impl Into<Next<UpdateTransState>> {
+        ) -> impl Into<Next<TesterState>> {
             self.top_down_update += 1;
-            Some(UpdateTransState::BA)
+            Some(TesterState::BA)
         }
     }
 }
@@ -221,7 +220,7 @@ mod update_trans {
 #[test]
 fn state_chart() {
     assert_eq!(
-        UPDATE_TRANS_STATE_CHART,
+        TESTER_STATE_CHART,
         "Top
 ├─ A
 │  └─ AA
@@ -234,14 +233,14 @@ fn state_chart() {
 
 #[test]
 fn update() {
-    let mut machine = UpdateTransMachineBuilder::new(Top {
+    let mut machine = TesterMachineBuilder::new(Top {
         update: 0,
         top_down_update: 0,
     })
     .build();
 
-    machine.transition(UpdateTransState::AA);
-    assert!(matches!(machine.state(), UpdateTransState::AA));
+    machine.transition(TesterState::AA);
+    assert!(matches!(machine.state(), TesterState::AA));
 
     assert_eq!(machine.top_ref().update, 0);
 
@@ -252,7 +251,7 @@ fn update() {
     assert_eq!(aa.update, 0);
 
     machine.update();
-    assert!(matches!(machine.state(), UpdateTransState::BA));
+    assert!(matches!(machine.state(), TesterState::BA));
 
     assert_eq!(machine.top_ref().update, 1);
 
@@ -263,7 +262,7 @@ fn update() {
     assert_eq!(ba.update, 0);
 
     machine.update();
-    assert!(matches!(machine.state(), UpdateTransState::BA));
+    assert!(matches!(machine.state(), TesterState::BA));
 
     assert_eq!(machine.top_ref().update, 2);
 
@@ -273,11 +272,11 @@ fn update() {
     let ba: &BA = machine.state_ref().unwrap();
     assert_eq!(ba.update, 1);
 
-    machine.transition(UpdateTransState::BBA);
-    assert!(matches!(machine.state(), UpdateTransState::BBA));
+    machine.transition(TesterState::BBA);
+    assert!(matches!(machine.state(), TesterState::BBA));
 
     machine.update();
-    assert!(matches!(machine.state(), UpdateTransState::BA));
+    assert!(matches!(machine.state(), TesterState::BA));
 
     assert_eq!(machine.top_ref().update, 3);
 
@@ -290,14 +289,14 @@ fn update() {
 
 #[test]
 fn top_down_update() {
-    let mut machine = UpdateTransMachineBuilder::new(Top {
+    let mut machine = TesterMachineBuilder::new(Top {
         update: 0,
         top_down_update: 0,
     })
     .build();
 
-    machine.transition(UpdateTransState::AA);
-    assert!(matches!(machine.state(), UpdateTransState::AA));
+    machine.transition(TesterState::AA);
+    assert!(matches!(machine.state(), TesterState::AA));
 
     assert_eq!(machine.top_ref().top_down_update, 0);
 
@@ -308,7 +307,7 @@ fn top_down_update() {
     assert_eq!(aa.top_down_update, 0);
 
     machine.top_down_update();
-    assert!(matches!(machine.state(), UpdateTransState::BA));
+    assert!(matches!(machine.state(), TesterState::BA));
 
     assert_eq!(machine.top_ref().top_down_update, 1);
 
@@ -319,7 +318,7 @@ fn top_down_update() {
     assert_eq!(ba.top_down_update, 1);
 
     machine.top_down_update();
-    assert!(matches!(machine.state(), UpdateTransState::BA));
+    assert!(matches!(machine.state(), TesterState::BA));
 
     assert_eq!(machine.top_ref().top_down_update, 2);
 


### PR DESCRIPTION
- The `Next` enum represents the possible outcomes of most `State` methods
- Exact transitions can now be used to force re-entrance